### PR TITLE
add tests for the osmuser model in the login app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ trainings/*
 backend/.env
 backend/config.txt
 backend/postgres-data
+# env folders
+.env/
+.venv/

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -23,3 +23,4 @@ osmconflator
 orthogonalizer
 fairpredictor==0.0.26
 tflite-runtime==2.14.0
+model-bakery==1.17.0

--- a/backend/tests/test_models_login.py
+++ b/backend/tests/test_models_login.py
@@ -1,0 +1,49 @@
+from django.test import TestCase
+from login.models import OsmUser
+from model_bakery import baker
+
+
+class OsmUserModelTest(TestCase):
+    def setUp(self):
+        # Set up non-modified objects used by all test methods
+        self.user = baker.make(OsmUser, username="test_user", password="test_password", osm_id=12345)
+
+    def test_create_user(self):
+        # Test case for creating a user, checking the username, password, and osm_id.
+        self.assertEqual(self.user.username, "test_user")
+        self.assertEqual(self.user.password, "test_password")
+        self.assertEqual(self.user.osm_id, 12345)
+
+    def test_create_duplicate_user_fails(self):
+        # Creating the exact same user should fail because of duplication.
+        with self.assertRaises(Exception):
+            baker.make(OsmUser, username="test_user", password="test_password", osm_id=12345)
+
+    def test_create_invalid_user_fails(self):
+        # Creating a user without a username should fail.
+        with self.assertRaises(Exception):
+            baker.make(OsmUser, password="test_password", osm_id=12345)           
+
+    def test_missing_osm_id_fails(self):
+        # Creating a user without osm_id should fail.
+        with self.assertRaises(Exception):
+            baker.make(OsmUser, username="test_user", password="test_password")
+
+    def test_string_representation(self):
+        # Test the string representation of an OsmUser instance
+        self.assertEqual(str(self.user), self.user.username)
+
+    def test_string_representation_with_different_username(self):
+        # Test the string representation of an OsmUser instance with a different username
+        self.user.username = "different_user"
+        self.assertEqual(str(self.user), self.user.username)
+
+    def test_string_representation_with_different_osm_id(self):
+        # Test the string representation of an OsmUser instance with a different osm_id
+        self.user.osm_id = 54321
+        self.assertEqual(str(self.user), self.user.username)
+
+    def test_string_representation_with_different_password(self):
+        # Test the string representation of an OsmUser instance with a different password
+        self.user.password = "different_password"
+        self.assertEqual(str(self.user), self.user.username)


### PR DESCRIPTION
## What does this PR do?
This PR adds tests specifically for models in the login app of this project.

Contributes to resolving issue: https://github.com/hotosm/fAIr/issues/229

## Considerations
I also modified the .gitignore to include .venv and .env folder to avoid accidentally committing files in those folders.

I added Model bakery to the requirements because of it's ease of use in implementing tests.

## How to test?
The test for the models in the core app can be run with `python manage.py test tests.test_models_login`.