### PR TITLE
add working tests for the login view

### DIFF
--- a/backend/tests/test_views_login.py
+++ b/backend/tests/test_views_login.py
@@ -1,0 +1,20 @@
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+client = APIClient()
+
+API_BASE = "http://testserver/api/v1"
+
+
+class LoginViewTestCase(TestCase):
+    def test_login_url_returns_200(self):
+        response = client.get(f"{API_BASE}/auth/login/")
+        self.assertEqual(response.status_code, 200)
+
+    def test_response_type_is_json(self):
+        response = client.get(f"{API_BASE}/auth/login/")
+        self.assertEqual(response["content-type"], "application/json")
+
+    def test_response_contains_login_url(self):
+        response = client.get(f"{API_BASE}/auth/login/")
+        self.assertTrue("login_url" in response.json())


### PR DESCRIPTION
### What does this PR do?
This PR adds a test for the login view in the login app of the project.

Contributes to resolving issue: https://github.com/hotosm/fAIr/issues/229

### Considerations
While looking at how to test the other views in the file, I had issues with the user not being logged in/authentication so I didn't test the `GetMyData` and `callback` views.

### How to test?
You can run the specific tests for the views by running: `python manage.py test tests.test_views_login`. 

